### PR TITLE
Add a fade transition, transition target, and basic appearance functionality

### DIFF
--- a/MotionTransitions.podspec
+++ b/MotionTransitions.podspec
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   s.public_header_files = "src/*.h"
   s.source_files = "src/*.{h,m,mm}", "src/private/*.{h,m,mm}"
 
-  s.dependency "MotionAnimator"
-  s.dependency "MotionTransitioning"
+  s.dependency "MotionAnimator", "~> 1.1"
+  s.dependency "MotionTransitioning", "~> 3.2"
 end

--- a/MotionTransitions.podspec
+++ b/MotionTransitions.podspec
@@ -13,5 +13,6 @@ Pod::Spec.new do |s|
   s.source_files = "src/*.{h,m,mm}", "src/private/*.{h,m,mm}"
 
   s.dependency "MotionAnimator", "~> 1.1"
+  s.dependency "MotionInterchange", "~> 1.1"
   s.dependency "MotionTransitioning", "~> 3.2"
 end

--- a/Podfile
+++ b/Podfile
@@ -5,6 +5,7 @@ platform :ios, '8.0'
 target "Catalog" do
   pod 'CatalogByConvention'
   pod 'MotionTransitions', :path => './'
+  pod 'MotionInterchange', :path => '../motion-interchange-objc'
 
   project 'examples/apps/Catalog/Catalog.xcodeproj'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,28 +1,31 @@
 PODS:
   - CatalogByConvention (2.1.1)
-  - MotionAnimator (1.1.0):
+  - MotionAnimator (1.1.2):
     - MotionInterchange
   - MotionInterchange (1.0.1)
-  - MotionTransitioning (3.1.0)
+  - MotionTransitioning (3.2.1)
   - MotionTransitions (1.0.0):
-    - MotionAnimator
-    - MotionTransitioning
+    - MotionAnimator (~> 1.1)
+    - MotionTransitioning (~> 3.2)
 
 DEPENDENCIES:
   - CatalogByConvention
+  - MotionInterchange (from `../motion-interchange-objc`)
   - MotionTransitions (from `./`)
 
 EXTERNAL SOURCES:
+  MotionInterchange:
+    :path: "../motion-interchange-objc"
   MotionTransitions:
     :path: "./"
 
 SPEC CHECKSUMS:
   CatalogByConvention: c3a5319de04250a7cd4649127fcfca5fe3322a43
-  MotionAnimator: 9d025cda7572737e5db5ca779eb28c767fe6cf45
+  MotionAnimator: 5a1893b58fcf7a4664d81d69c9a09a0078c67e06
   MotionInterchange: 7a7c355ba2ed5d36c5cf2ceb76cacd3d3680dbf5
-  MotionTransitioning: 5a4188866a5b016f7181dd41c1a14f93809688ec
-  MotionTransitions: f28df95c5a17c05513e2a2b9daffa0649bfb2df6
+  MotionTransitioning: 01e7fcd6e2974985057109e0a4c98ea546cd5947
+  MotionTransitions: 8bd0c2d1f0cf760133073af1cbeef8c62cc11ed7
 
-PODFILE CHECKSUM: d7d866496023cbed0b29d2df862884181684f12b
+PODFILE CHECKSUM: '0168291e452a0f2f4ba6c4ee580485754047be78'
 
 COCOAPODS: 1.2.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,10 +2,11 @@ PODS:
   - CatalogByConvention (2.1.1)
   - MotionAnimator (1.1.2):
     - MotionInterchange
-  - MotionInterchange (1.0.1)
+  - MotionInterchange (1.1.0)
   - MotionTransitioning (3.2.1)
   - MotionTransitions (1.0.0):
     - MotionAnimator (~> 1.1)
+    - MotionInterchange (~> 1.1)
     - MotionTransitioning (~> 3.2)
 
 DEPENDENCIES:
@@ -22,9 +23,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   CatalogByConvention: c3a5319de04250a7cd4649127fcfca5fe3322a43
   MotionAnimator: 5a1893b58fcf7a4664d81d69c9a09a0078c67e06
-  MotionInterchange: 7a7c355ba2ed5d36c5cf2ceb76cacd3d3680dbf5
+  MotionInterchange: b600100244df56c4f462bdacbcd11c44e6305d05
   MotionTransitioning: 01e7fcd6e2974985057109e0a4c98ea546cd5947
-  MotionTransitions: 8bd0c2d1f0cf760133073af1cbeef8c62cc11ed7
+  MotionTransitions: 3d7f50fbb45b50d470316f2cd51f21feb099e032
 
 PODFILE CHECKSUM: '0168291e452a0f2f4ba6c4ee580485754047be78'
 

--- a/examples/FadeTransitionExampleViewController.swift
+++ b/examples/FadeTransitionExampleViewController.swift
@@ -1,0 +1,40 @@
+/*
+ Copyright 2017-present The Material Motion Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import UIKit
+import MotionTransitions
+
+class FadeTransitionExampleViewController: UIViewController {
+
+  override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+    super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+
+    title = "Fade"
+
+    self.transitionController.transition = FadeTransition()
+  }
+
+  required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    view.backgroundColor = .lightGray
+  }
+}
+

--- a/examples/apps/Catalog/Catalog.xcodeproj/project.pbxproj
+++ b/examples/apps/Catalog/Catalog.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		661E64EE1F82951E00E33098 /* FadeTransitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 661E64ED1F82951E00E33098 /* FadeTransitionTests.swift */; };
+		661E64F01F829AB800E33098 /* TransitionTargetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 661E64EF1F829AB800E33098 /* TransitionTargetTests.swift */; };
 		666FAA841D384A6B000363DA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 666FAA831D384A6B000363DA /* AppDelegate.swift */; };
 		666FAA8B1D384A6B000363DA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 666FAA8A1D384A6B000363DA /* Assets.xcassets */; };
 		666FAA8E1D384A6B000363DA /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 666FAA8C1D384A6B000363DA /* LaunchScreen.storyboard */; };
@@ -37,6 +39,8 @@
 
 /* Begin PBXFileReference section */
 		27E00ABDE052BFA8DA54FF17 /* Pods_Catalog.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Catalog.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		661E64ED1F82951E00E33098 /* FadeTransitionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FadeTransitionTests.swift; sourceTree = "<group>"; };
+		661E64EF1F829AB800E33098 /* TransitionTargetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransitionTargetTests.swift; sourceTree = "<group>"; };
 		666FAA801D384A6B000363DA /* Catalog.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Catalog.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		666FAA831D384A6B000363DA /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = Catalog/AppDelegate.swift; sourceTree = "<group>"; };
 		666FAA8A1D384A6B000363DA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -131,6 +135,8 @@
 		666FAA971D384A6B000363DA /* tests */ = {
 			isa = PBXGroup;
 			children = (
+				661E64ED1F82951E00E33098 /* FadeTransitionTests.swift */,
+				661E64EF1F829AB800E33098 /* TransitionTargetTests.swift */,
 			);
 			name = tests;
 			path = ../../../tests/unit;
@@ -271,7 +277,7 @@
 					};
 					666FAA931D384A6B000363DA = {
 						CreatedOnToolsVersion = 7.3.1;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0900;
 						TestTargetID = 667A3F3E1DEE269400CB3A99;
 					};
 					667A3F3E1DEE269400CB3A99 = {
@@ -435,6 +441,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				661E64EE1F82951E00E33098 /* FadeTransitionTests.swift in Sources */,
+				661E64F01F829AB800E33098 /* TransitionTargetTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/examples/apps/Catalog/Catalog.xcodeproj/project.pbxproj
+++ b/examples/apps/Catalog/Catalog.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		66175B7B1F83D86100B14EAB /* FadeTransitionExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66175B7A1F83D86100B14EAB /* FadeTransitionExampleViewController.swift */; };
 		661E64EE1F82951E00E33098 /* FadeTransitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 661E64ED1F82951E00E33098 /* FadeTransitionTests.swift */; };
 		661E64F01F829AB800E33098 /* TransitionTargetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 661E64EF1F829AB800E33098 /* TransitionTargetTests.swift */; };
 		666FAA841D384A6B000363DA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 666FAA831D384A6B000363DA /* AppDelegate.swift */; };
@@ -39,6 +40,7 @@
 
 /* Begin PBXFileReference section */
 		27E00ABDE052BFA8DA54FF17 /* Pods_Catalog.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Catalog.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		66175B7A1F83D86100B14EAB /* FadeTransitionExampleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FadeTransitionExampleViewController.swift; sourceTree = "<group>"; };
 		661E64ED1F82951E00E33098 /* FadeTransitionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FadeTransitionTests.swift; sourceTree = "<group>"; };
 		661E64EF1F829AB800E33098 /* TransitionTargetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransitionTargetTests.swift; sourceTree = "<group>"; };
 		666FAA801D384A6B000363DA /* Catalog.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Catalog.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -145,6 +147,7 @@
 		666FAAA31D384B13000363DA /* examples */ = {
 			isa = PBXGroup;
 			children = (
+				66175B7A1F83D86100B14EAB /* FadeTransitionExampleViewController.swift */,
 			);
 			name = examples;
 			path = ../..;
@@ -432,6 +435,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				66175B7B1F83D86100B14EAB /* FadeTransitionExampleViewController.swift in Sources */,
 				666FAA841D384A6B000363DA /* AppDelegate.swift in Sources */,
 				667A3F541DEE273000CB3A99 /* TableOfContents.swift in Sources */,
 			);

--- a/examples/apps/Catalog/Catalog/AppDelegate.swift
+++ b/examples/apps/Catalog/Catalog/AppDelegate.swift
@@ -16,6 +16,7 @@
 
 import UIKit
 import CatalogByConvention
+import MotionTransitioning
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -28,7 +29,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     let rootViewController = CBCNodeListViewController(node: CBCCreateNavigationTree())
     rootViewController.title = "Motion Transitions"
-    window.rootViewController = UINavigationController(rootViewController: rootViewController)
+    let navigationController = UINavigationController(rootViewController: rootViewController)
+    navigationController.delegate = TransitionNavigationControllerDelegate.sharedDelegate()
+    window.rootViewController = navigationController
 
     window.makeKeyAndVisible()
     return true

--- a/examples/apps/Catalog/TableOfContents.swift
+++ b/examples/apps/Catalog/TableOfContents.swift
@@ -16,12 +16,8 @@
 
 // MARK: Catalog by convention
 
-// Example entry in the table of contents:
-// Extend a UIViewController instance and implement catalogBreadcrumbs(), returning the list of
-// breadcrumbs required to navigate to an instance of this view controller.
-//
-//extension ExampleViewController {
-//  class func catalogBreadcrumbs() -> [String] {
-//    return ["Example"]
-//  }
-//}
+extension FadeTransitionExampleViewController {
+  class func catalogBreadcrumbs() -> [String] {
+    return ["Fade transition"]
+  }
+}

--- a/src/MDMFadeTransition.h
+++ b/src/MDMFadeTransition.h
@@ -51,14 +51,14 @@ MDMSUBCLASSING_RESTRICTED
  The motion timing to use for this fade transition.
 
  By default the animation will use the system default timing function with a duration lasting the
- entire transition.
-
- By default the timing duration and delay are treated as relative to the transition's overall
- duration. To treat these values as absolute time values, enable useAbsoluteTiming.
+ entire transition. The timing duration and delay are treated as relative to the transition's
+ overall duration. To treat these values as absolute time values, change the timingMode to absolute.
  */
 @property(nonatomic, assign) MDMMotionTiming timing;
 
 /**
+ The timing mode affects how the `timing` data is interpreted.
+
  Default value is MDMTransitionTimingModeMirrored.
  */
 @property(nonatomic, assign) MDMTransitionTimingMode timingMode;

--- a/src/MDMFadeTransition.h
+++ b/src/MDMFadeTransition.h
@@ -1,0 +1,73 @@
+/*
+ Copyright 2017-present The Material Motion Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+@import Foundation;
+@import MotionInterchange;
+@import MotionTransitioning;
+
+#import "MDMTransitionAppearance.h"
+#import "MDMTransitionTimingMode.h"
+#import "MDMTransitionTarget.h"
+
+/**
+ A view controller transition component for fading a target view.
+
+ The target view can be faded in or out with custom timing.
+ */
+NS_SWIFT_NAME(FadeTransition)
+MDMSUBCLASSING_RESTRICTED
+@interface MDMFadeTransition : NSObject <MDMTransition>
+
+/**
+ Initializes the transition instance with a specific target.
+
+ The target view will fade in or out according to the timing information configured on this
+ instance.
+ */
+- (nonnull instancetype)initWithTarget:(nonnull MDMTransitionTarget *)target
+  NS_DESIGNATED_INITIALIZER;
+
+/**
+ Initializes the transition with the fore view as the target.
+ */
+- (nonnull instancetype)init;
+
+/**
+ The motion timing to use for this fade transition.
+
+ By default the animation will use the system default timing function with a duration lasting the
+ entire transition.
+
+ By default the timing duration and delay are treated as relative to the transition's overall
+ duration. To treat these values as absolute time values, enable useAbsoluteTiming.
+ */
+@property(nonatomic, assign) MDMMotionTiming timing;
+
+/**
+ Default value is MDMTransitionTimingModeMirrored.
+ */
+@property(nonatomic, assign) MDMTransitionTimingMode timingMode;
+
+/**
+ Whether the target is transitioning in to or out of view.
+
+ If the appearance is `.in`, the target will fade in, otherwise the target will fade out.
+
+ Default value is `.in`.
+ */
+@property(nonatomic, assign) MDMTransitionAppearance appearance;
+
+@end

--- a/src/MDMFadeTransition.h
+++ b/src/MDMFadeTransition.h
@@ -36,6 +36,8 @@ MDMSUBCLASSING_RESTRICTED
 
  The target view will fade in or out according to the timing information configured on this
  instance.
+ 
+ @param target The target view to be animated.
  */
 - (nonnull instancetype)initWithTarget:(nonnull MDMTransitionTarget *)target
   NS_DESIGNATED_INITIALIZER;

--- a/src/MDMFadeTransition.m
+++ b/src/MDMFadeTransition.m
@@ -30,7 +30,7 @@ static MDMMotionCurve ReverseTimingCurve(MDMMotionCurve timingCurve) {
 }
 
 @implementation MDMFadeTransition {
-  MDMTransitionTarget *_target;
+  MDMTransitionTarget * _Nonnull _target;
 }
 
 - (instancetype)initWithTarget:(MDMTransitionTarget *)target {
@@ -67,7 +67,6 @@ static MDMMotionCurve ReverseTimingCurve(MDMMotionCurve timingCurve) {
   switch (_timingMode) {
     case MDMTransitionTimingModeMirrored:
       animator.timeScaleFactor = context.duration;
-
       animator.shouldReverseValues = context.direction == MDMTransitionDirectionBackward;
 
       if (context.direction == MDMTransitionDirectionBackward) {

--- a/src/MDMFadeTransition.m
+++ b/src/MDMFadeTransition.m
@@ -1,0 +1,102 @@
+/*
+ Copyright 2017-present The Material Motion Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDMFadeTransition.h"
+
+@import MotionAnimator;
+
+static MDMMotionCurve ReverseTimingCurve(MDMMotionCurve timingCurve) {
+  MDMMotionCurve reversed = timingCurve;
+  if (timingCurve.type == MDMMotionCurveTypeBezier) {
+    reversed.data[0] = 1 - reversed.data[2];
+    reversed.data[1] = 1 - reversed.data[3];
+    reversed.data[2] = 1 - reversed.data[0];
+    reversed.data[3] = 1 - reversed.data[1];
+  }
+  return reversed;
+}
+
+@implementation MDMFadeTransition {
+  MDMTransitionTarget *_target;
+}
+
+- (instancetype)initWithTarget:(MDMTransitionTarget *)target {
+  self = [super init];
+  if (self) {
+    _target = target;
+    _appearance = MDMTransitionAppearanceAppearing;
+    _timingMode = MDMTransitionTimingModeMirrored;
+
+    CAMediaTimingFunction *defaultTiming = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionDefault];
+    _timing = (MDMMotionTiming){
+      .duration = 1,
+      .curve = MDMMotionCurveFromTimingFunction(defaultTiming)
+    };
+  }
+  return self;
+}
+
+- (instancetype)init {
+  return [self initWithTarget:[MDMTransitionTarget targetWithForeView]];
+}
+
+#pragma mark - MDMTransition
+
+- (void)startWithContext:(id<MDMTransitionContext>)context {
+  [CATransaction begin];
+  [CATransaction setCompletionBlock:^{
+    [context transitionDidEnd];
+  }];
+
+  MDMMotionAnimator *animator = [[MDMMotionAnimator alloc] init];
+
+  MDMMotionTiming timing = _timing;
+  switch (_timingMode) {
+    case MDMTransitionTimingModeMirrored:
+      animator.timeScaleFactor = context.duration;
+
+      animator.shouldReverseValues = context.direction == MDMTransitionDirectionBackward;
+
+      if (context.direction == MDMTransitionDirectionBackward) {
+        timing.delay = 1 - (timing.delay + timing.duration);
+        timing.curve = ReverseTimingCurve(timing.curve);
+      }
+      break;
+
+    case MDMTransitionTimingModeRelative:
+      animator.timeScaleFactor = context.duration;
+      break;
+
+    case MDMTransitionTimingModeAbsolute:
+      // No-op.
+      break;
+  }
+
+  NSArray *inValues = @[@0, @1];
+  NSArray *outValues = [[inValues reverseObjectEnumerator] allObjects];
+  NSArray *values = (_appearance == MDMTransitionAppearanceAppearing) ? inValues : outValues;
+
+  UIView *target = [_target resolveWithContext:context];
+
+  [animator animateWithTiming:timing
+                      toLayer:target.layer
+                   withValues:values
+                      keyPath:MDMKeyPathOpacity];
+
+  [CATransaction commit];
+}
+
+@end

--- a/src/MDMTransitionAppearance.h
+++ b/src/MDMTransitionAppearance.h
@@ -14,7 +14,21 @@
  limitations under the License.
  */
 
-#import "MDMFadeTransition.h"
-#import "MDMTransitionAppearance.h"
-#import "MDMTransitionTimingMode.h"
-#import "MDMTransitionTarget.h"
+@import Foundation;
+
+/**
+ Whether a target is becoming visible or will no longer be visible by the end of a transition.
+ */
+typedef NS_ENUM(NSUInteger, MDMTransitionAppearance) {
+
+  /**
+   The target element will become visible.
+   */
+  MDMTransitionAppearanceAppearing,
+
+  /**
+   The target element will no longer be visible.
+   */
+  MDMTransitionAppearanceDisappearing,
+
+} NS_SWIFT_NAME(TransitionAppearance);

--- a/src/MDMTransitionTarget.h
+++ b/src/MDMTransitionTarget.h
@@ -47,6 +47,8 @@ NS_SWIFT_NAME(TransitionTarget)
 
 /**
  Returns the target view for the given context.
+
+ @param context The transition context this target should be resolved from.
  */
 - (nonnull UIView *)resolveWithContext:(nonnull id<MDMTransitionContext>)context;
 

--- a/src/MDMTransitionTarget.h
+++ b/src/MDMTransitionTarget.h
@@ -42,6 +42,8 @@ NS_SWIFT_NAME(TransitionTarget)
 
 /**
  Creates a target referring to the provided view.
+
+ @param view The provided view will be returned by resolveWithContext, regardless of the context.
  */
 + (nonnull instancetype)targetWithView:(nonnull UIView *)view;
 

--- a/src/MDMTransitionTarget.h
+++ b/src/MDMTransitionTarget.h
@@ -1,0 +1,56 @@
+/*
+ Copyright 2017-present The Material Motion Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+@import Foundation;
+@import UIKit;
+@import MotionTransitioning;
+
+#if defined(__has_attribute) && __has_attribute(objc_subclassing_restricted)
+#define MDMSUBCLASSING_RESTRICTED __attribute__((objc_subclassing_restricted))
+#else
+#define MDMSUBCLASSING_RESTRICTED
+#endif
+
+/**
+ A target for a view controller transition.
+ */
+NS_SWIFT_NAME(TransitionTarget)
+@interface MDMTransitionTarget : NSObject
+
+/**
+ Creates a target referring to the back view controller's view.
+ */
++ (nonnull instancetype)targetWithBackView;
+
+/**
+ Creates a target referring to the fore view controller's view.
+ */
++ (nonnull instancetype)targetWithForeView;
+
+/**
+ Creates a target referring to the provided view.
+ */
++ (nonnull instancetype)targetWithView:(nonnull UIView *)view;
+
+/**
+ Returns the target view for the given context.
+ */
+- (nonnull UIView *)resolveWithContext:(nonnull id<MDMTransitionContext>)context;
+
+// Unavailable. Use any of the static targetWith methods instead.
+- (nonnull instancetype)init NS_UNAVAILABLE;
+
+@end

--- a/src/MDMTransitionTarget.m
+++ b/src/MDMTransitionTarget.m
@@ -30,28 +30,28 @@ typedef NS_ENUM(NSUInteger, Target) {
 }
 
 + (instancetype)targetWithBackView {
-  MDMTransitionTarget *target = [[[self class] alloc] init];
-  if (target) {
-    target->_target = TargetBack;
+  MDMTransitionTarget *transitionTarget = [[[self class] alloc] init];
+  if (transitionTarget) {
+    transitionTarget->_target = TargetBack;
   }
-  return target;
+  return transitionTarget;
 }
 
 + (instancetype)targetWithForeView {
-  MDMTransitionTarget *target = [[[self class] alloc] init];
-  if (target) {
-    target->_target = TargetFore;
+  MDMTransitionTarget *transitionTarget = [[[self class] alloc] init];
+  if (transitionTarget) {
+    transitionTarget->_target = TargetFore;
   }
-  return target;
+  return transitionTarget;
 }
 
 + (instancetype)targetWithView:(UIView *)view {
-  MDMTransitionTarget *target = [[[self class] alloc] init];
-  if (target) {
-    target->_target = TargetView;
-    target->_targetView = view;
+  MDMTransitionTarget *transitionTarget = [[[self class] alloc] init];
+  if (transitionTarget) {
+    transitionTarget->_target = TargetView;
+    transitionTarget->_targetView = view;
   }
-  return target;
+  return transitionTarget;
 }
 
 - (UIView *)resolveWithContext:(id<MDMTransitionContext>)context {

--- a/src/MDMTransitionTarget.m
+++ b/src/MDMTransitionTarget.m
@@ -1,0 +1,74 @@
+/*
+ Copyright 2017-present The Material Motion Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDMTransitionTarget.h"
+
+@import MotionTransitioning;
+
+typedef NS_ENUM(NSUInteger, Target) {
+  TargetBack,
+  TargetFore,
+  TargetView,
+};
+
+@implementation MDMTransitionTarget {
+  Target _target;
+  UIView *_targetView; // Valid only if _target == TargetView
+}
+
++ (instancetype)targetWithBackView {
+  MDMTransitionTarget *target = [[[self class] alloc] init];
+  if (target) {
+    target->_target = TargetBack;
+  }
+  return target;
+}
+
++ (instancetype)targetWithForeView {
+  MDMTransitionTarget *target = [[[self class] alloc] init];
+  if (target) {
+    target->_target = TargetFore;
+  }
+  return target;
+}
+
++ (instancetype)targetWithView:(UIView *)view {
+  MDMTransitionTarget *target = [[[self class] alloc] init];
+  if (target) {
+    target->_target = TargetView;
+    target->_targetView = view;
+  }
+  return target;
+}
+
+- (UIView *)resolveWithContext:(id<MDMTransitionContext>)context {
+  switch (_target) {
+    case TargetBack:
+      return context.backViewController.view;
+      break;
+
+    case TargetFore:
+      return context.foreViewController.view;
+      break;
+
+    case TargetView:
+      return _targetView;
+      break;
+  }
+  return nil;
+}
+
+@end

--- a/src/MDMTransitionTimingMode.h
+++ b/src/MDMTransitionTimingMode.h
@@ -1,0 +1,57 @@
+/*
+ Copyright 2017-present The Material Motion Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+@import Foundation;
+
+/**
+ The timing mode affects how the timing and internal values of the animation are understood.
+ */
+typedef NS_ENUM(NSUInteger, MDMTransitionTimingMode) {
+
+  /**
+   The delay and duration will be treated as relative to the transition's overall duration and the
+   timing will be reversed when the transition goes backwards.
+
+   Animation values will be reversed.
+
+   For example, a delay of 0 and duration of 1 means the animation lasts the entire transition,
+   while a delay of 0.5 and duration of 1 means the animation happens in the last half of the
+   transition.
+   */
+  MDMTransitionTimingModeMirrored,
+
+  /**
+   The delay and duration will be treated as relative to the transition's overall duration.
+
+   Animation values will NOT be reversed.
+
+   For example, a delay of 0 and duration of 1 means the animation lasts the entire transition,
+   while a delay of 0.5 and duration of 1 means the animation happens in the last half of the
+   transition.
+   */
+  MDMTransitionTimingModeRelative,
+
+  /**
+   The delay and duration will be treated as absolute timing.
+
+   Animation values will NOT be reversed.
+
+   For example, a delay of 0.1 and duration of 0.3 means the animation will wait 1/10th of a second
+   before animating for 3/10ths of a second.
+   */
+  MDMTransitionTimingModeAbsolute,
+
+} NS_SWIFT_NAME(TransitionTimingMode);

--- a/src/MaterialMotionTransitions.h
+++ b/src/MaterialMotionTransitions.h
@@ -16,5 +16,5 @@
 
 #import "MDMFadeTransition.h"
 #import "MDMTransitionAppearance.h"
-#import "MDMTransitionTimingMode.h"
 #import "MDMTransitionTarget.h"
+#import "MDMTransitionTimingMode.h"

--- a/tests/unit/FadeTransitionTests.swift
+++ b/tests/unit/FadeTransitionTests.swift
@@ -1,0 +1,162 @@
+/*
+ Copyright 2017-present The Material Motion Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import XCTest
+import MotionTransitions
+
+class FadeTransitionTests: XCTestCase {
+
+  private var window: UIWindow!
+  override func setUp() {
+    window = UIWindow()
+    window.rootViewController = UIViewController()
+    window.makeKeyAndVisible()
+    window.layer.speed = 10
+  }
+
+  override func tearDown() {
+    window = nil
+  }
+
+  func testDoesComplete() {
+    let presentedViewController = UIViewController()
+    presentedViewController.transitionController.transition = FadeTransition()
+
+    let didComplete = expectation(description: "Did complete")
+    window.rootViewController!.present(presentedViewController, animated: true) {
+      didComplete.fulfill()
+    }
+
+    waitForExpectations(timeout: 0.1)
+
+    XCTAssertEqual(window.rootViewController!.presentedViewController, presentedViewController)
+  }
+
+  func testDoesFadeIn() {
+    let presentedViewController = UIViewController()
+    presentedViewController.transitionController.transition = FadeTransition()
+
+    let didComplete = expectation(description: "Did complete")
+    window.rootViewController!.present(presentedViewController, animated: true) {
+      didComplete.fulfill()
+    }
+
+    waitForExpectations(timeout: 0.1)
+
+    XCTAssertEqual(presentedViewController.view.layer.opacity, 1)
+  }
+
+  func testDoesFadeOutDuringDismissal() {
+    let presentedViewController = UIViewController()
+    presentedViewController.transitionController.transition = FadeTransition()
+
+    let didComplete = expectation(description: "Did complete")
+    window.rootViewController!.present(presentedViewController, animated: true) {
+      didComplete.fulfill()
+    }
+
+    waitForExpectations(timeout: 0.1)
+
+    let didDismiss = expectation(description: "Did complete")
+    presentedViewController.dismiss(animated: true) {
+      didDismiss.fulfill()
+    }
+
+    waitForExpectations(timeout: 0.1)
+
+    XCTAssertEqual(presentedViewController.view.layer.opacity, 0)
+  }
+
+  func testDoesFadeOut() {
+    let presentedViewController = UIViewController()
+    let transition = FadeTransition()
+    transition.appearance = .disappearing
+    presentedViewController.transitionController.transition = transition
+
+    let didComplete = expectation(description: "Did complete")
+    window.rootViewController!.present(presentedViewController, animated: true) {
+      didComplete.fulfill()
+    }
+
+    waitForExpectations(timeout: 0.1)
+
+    XCTAssertEqual(presentedViewController.view.layer.opacity, 0)
+
+    let didDismiss = expectation(description: "Did complete")
+    presentedViewController.dismiss(animated: true) {
+      didDismiss.fulfill()
+    }
+
+    waitForExpectations(timeout: 0.1)
+
+    XCTAssertEqual(presentedViewController.view.layer.opacity, 1)
+  }
+
+  func testResolvesBackTarget() {
+    let presentedViewController = UIViewController()
+    let transition = FadeTransition(target: .withBackView())
+    transition.appearance = .disappearing
+    presentedViewController.transitionController.transition = transition
+
+    let didComplete = expectation(description: "Did complete")
+    window.rootViewController!.present(presentedViewController, animated: true) {
+      didComplete.fulfill()
+    }
+
+    waitForExpectations(timeout: 0.1)
+
+    XCTAssertEqual(window.rootViewController!.view.layer.opacity, 0)
+
+    let didDismiss = expectation(description: "Did complete")
+    presentedViewController.dismiss(animated: true) {
+      didDismiss.fulfill()
+    }
+
+    waitForExpectations(timeout: 0.1)
+
+    XCTAssertEqual(window.rootViewController!.view.layer.opacity, 1)
+  }
+
+  func testResolvesCustomTarget() {
+    let presentedViewController = UIViewController()
+
+    let customView = UIView()
+    presentedViewController.view.addSubview(customView)
+
+    let transition = FadeTransition(target: .init(view: customView))
+    transition.appearance = .disappearing
+    presentedViewController.transitionController.transition = transition
+
+    let didComplete = expectation(description: "Did complete")
+    window.rootViewController!.present(presentedViewController, animated: true) {
+      didComplete.fulfill()
+    }
+
+    waitForExpectations(timeout: 0.1)
+
+    XCTAssertEqual(customView.layer.opacity, 0)
+
+    let didDismiss = expectation(description: "Did complete")
+    presentedViewController.dismiss(animated: true) {
+      didDismiss.fulfill()
+    }
+
+    waitForExpectations(timeout: 0.1)
+
+    XCTAssertEqual(customView.layer.opacity, 1)
+  }
+}
+

--- a/tests/unit/FadeTransitionTests.swift
+++ b/tests/unit/FadeTransitionTests.swift
@@ -70,7 +70,7 @@ class FadeTransitionTests: XCTestCase {
 
     waitForExpectations(timeout: 0.1)
 
-    let didDismiss = expectation(description: "Did complete")
+    let didDismiss = expectation(description: "Did dismiss")
     presentedViewController.dismiss(animated: true) {
       didDismiss.fulfill()
     }
@@ -95,7 +95,7 @@ class FadeTransitionTests: XCTestCase {
 
     XCTAssertEqual(presentedViewController.view.layer.opacity, 0)
 
-    let didDismiss = expectation(description: "Did complete")
+    let didDismiss = expectation(description: "Did dismiss")
     presentedViewController.dismiss(animated: true) {
       didDismiss.fulfill()
     }
@@ -120,7 +120,7 @@ class FadeTransitionTests: XCTestCase {
 
     XCTAssertEqual(window.rootViewController!.view.layer.opacity, 0)
 
-    let didDismiss = expectation(description: "Did complete")
+    let didDismiss = expectation(description: "Did dismiss")
     presentedViewController.dismiss(animated: true) {
       didDismiss.fulfill()
     }
@@ -149,7 +149,7 @@ class FadeTransitionTests: XCTestCase {
 
     XCTAssertEqual(customView.layer.opacity, 0)
 
-    let didDismiss = expectation(description: "Did complete")
+    let didDismiss = expectation(description: "Did dismiss")
     presentedViewController.dismiss(animated: true) {
       didDismiss.fulfill()
     }

--- a/tests/unit/TransitionTargetTests.swift
+++ b/tests/unit/TransitionTargetTests.swift
@@ -1,0 +1,68 @@
+/*
+ Copyright 2017-present The Material Motion Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import XCTest
+import MotionTransitions
+
+class MockTransitionContext: TransitionContext {
+  func transitionDidEnd() {
+  }
+
+  var direction: MDMTransitionDirection = .forward
+
+  var duration: TimeInterval = 0.1
+
+  var sourceViewController: UIViewController? = nil
+
+  var backViewController = UIViewController()
+
+  var foreViewController = UIViewController()
+
+  var containerView = UIView()
+
+  var presentationController: UIPresentationController? = nil
+
+  func `defer`(toCompletion work: @escaping () -> Void) {
+  }
+}
+
+class TransitionTargetTests: XCTestCase {
+
+  func testCustomTargetResolution() {
+    let targetView = UIView()
+    let target = TransitionTarget(view: targetView)
+    let resolvedView = target.resolve(with: MockTransitionContext())
+
+    XCTAssertEqual(targetView, resolvedView)
+  }
+
+  func testForeResolution() {
+    let target = TransitionTarget.withForeView()
+    let context = MockTransitionContext()
+    let resolvedView = target.resolve(with: context)
+
+    XCTAssertEqual(context.foreViewController.view, resolvedView)
+  }
+
+  func testBackResolution() {
+    let target = TransitionTarget.withBackView()
+    let context = MockTransitionContext()
+    let resolvedView = target.resolve(with: context)
+
+    XCTAssertEqual(context.backViewController.view, resolvedView)
+  }
+}
+


### PR DESCRIPTION
This PR includes the first modular transition instance, `FadeTransition`. This sets the foundation for a catalog of transition types.

Includes unit tests but no examples yet.

## As a standalone transition

By default, `FadeTransition` will fade in or out the fore view of the transition depending on the direction of the transition. This makes it easy to create a one-liner "fade" transition:

```swift
viewController.transitionController.transition = FadeTransition()
```

## As part of a larger transition

`FadeTransition` is also meant to be used as a modular part of a larger transition.

For example, say we wanted to fade a background element out:

```swift
final class MyCustomTransition: Transition {
  func start(with context: TransitionContext) {
    // ...other logic...

    let fadeTransition = FadeTransition(target: .target(view: backgroundView))
    fadeTransition.appearance = .disappearing
    context.compose(with: fadeTransition)

    // ...other logic...
  }
}
```

## Bidirectional by default

`FadeTransition` will mirror the transition values when the view controller is dismissed.

## New APIs

`MDMTransitionTarget` is essentially an enum type that can be one of three values:

1. The fore view.
2. The back view.
3. A custom view.

This object allows a transition builder to refer to the back and fore fixture views without having access to the view instances (commonly the case when assigning a Transition type to the transition controller).

`MDMTransitionAppearance` defines whether a view is appearing or disappearing.

`MDMTransitionTimingMode` is an enum of three possible timing mode interpretations:

1. Mirrored. The default.
2. Relative.
3. Absolute.

When mirrored, timing information is treated as relative and the animation values are automatically reversed when the transition is animating backward. This means a view that fades in during the last half of a presentation transition will fade **out** during the **first** half of the dismissal transition.

When relative, timing information is treated as relative and animation values are not reversed.

When absolute, timing information is treated as absolute and animation values are not reversed.