### PR TITLE
Minor code style fixes.

### DIFF
--- a/src/MDMFadeTransition.h
+++ b/src/MDMFadeTransition.h
@@ -15,8 +15,8 @@
  */
 
 #import "MDMTransitionAppearance.h"
-#import "MDMTransitionTimingMode.h"
 #import "MDMTransitionTarget.h"
+#import "MDMTransitionTimingMode.h"
 
 #import <MotionInterchange/MotionInterchange.h>
 #import <MotionTransitioning/MotionTransitioning.h>
@@ -29,7 +29,7 @@
  The target view can be faded in or out with custom timing.
  */
 NS_SWIFT_NAME(FadeTransition)
-MDMSUBCLASSING_RESTRICTED
+MDM_SUBCLASSING_RESTRICTED
 @interface MDMFadeTransition : NSObject <MDMTransition>
 
 /**

--- a/src/MDMFadeTransition.m
+++ b/src/MDMFadeTransition.m
@@ -16,7 +16,7 @@
 
 #import "MDMFadeTransition.h"
 
-@import MotionAnimator;
+#import "MotionAnimator.h"
 
 static MDMMotionCurve ReverseTimingCurve(MDMMotionCurve timingCurve) {
   MDMMotionCurve reversed = timingCurve;

--- a/src/MDMTransitionTarget.h
+++ b/src/MDMTransitionTarget.h
@@ -31,7 +31,6 @@
  A target for a view controller transition.
  */
 NS_SWIFT_NAME(TransitionTarget)
-MDM_SUBCLASSING_RESTRICTED
 @interface MDMTransitionTarget : NSObject
 
 /**

--- a/src/MDMTransitionTarget.h
+++ b/src/MDMTransitionTarget.h
@@ -19,16 +19,19 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
+#ifndef MDM_SUBCLASSING_RESTRICTED
 #if defined(__has_attribute) && __has_attribute(objc_subclassing_restricted)
-#define MDMSUBCLASSING_RESTRICTED __attribute__((objc_subclassing_restricted))
+#define MDM_SUBCLASSING_RESTRICTED __attribute__((objc_subclassing_restricted))
 #else
-#define MDMSUBCLASSING_RESTRICTED
+#define MDM_SUBCLASSING_RESTRICTED
 #endif
+#endif  // #ifndef MDM_SUBCLASSING_RESTRICTED
 
 /**
  A target for a view controller transition.
  */
 NS_SWIFT_NAME(TransitionTarget)
+MDM_SUBCLASSING_RESTRICTED
 @interface MDMTransitionTarget : NSObject
 
 /**

--- a/src/MDMTransitionTarget.m
+++ b/src/MDMTransitionTarget.m
@@ -16,7 +16,7 @@
 
 #import "MDMTransitionTarget.h"
 
-@import MotionTransitioning;
+#import "MotionTransitioning.h"
 
 typedef NS_ENUM(NSUInteger, Target) {
   TargetBack,


### PR DESCRIPTION
Replacing `@import` module statements with regular header imports because bazel doesn't tend to generate module names that match Xcode's.

`MDMSUBCLASSING_RESTRICTED` has been renamed to `MDM_SUBCLASSING_RESTRICTED` in order to stay consistent with the system framework macro naming conventions.